### PR TITLE
go-projectile-get: ensure directory exists

### DIFF
--- a/go-projectile.el
+++ b/go-projectile.el
@@ -237,6 +237,7 @@ DIR is the directory to use for GOPATH when running go get."
          (url (go-projectile-import-url url)))
     (if (file-exists-p default-directory)
         (error "%s already exists" default-directory))
+    (make-directory default-directory t)
     (setenv "GOPATH" default-directory)
     (let ((result (shell-command-to-string (concat "go get " url))))
       (unless (string= "" result)


### PR DESCRIPTION
Create the directory (and its parents) if it doesn't exist when calling
go-projectile-get.

Signed-off-by: Andrew McDermott <aim@frobware.com>