### PR TITLE
Remove deprecated projectile-keymap-prefix usage

### DIFF
--- a/go-projectile.el
+++ b/go-projectile.el
@@ -177,11 +177,10 @@ PATH defaults to GOPATH via getenv, used to determine if buffer is in current GO
 
 (defun go-projectile-set-local-keys ()
   "Set local Projectile key bindings for Go projects."
-  (dolist (map '(("W" go-projectile-rewrite)
-                 ("w" go-rename)
-                 ("N" go-projectile-get)
-                 ("G" go-projectile-git-grep)))
-    (local-set-key (kbd (concat projectile-keymap-prefix " " (car map))) (nth 1 map))))
+  (define-key projectile-command-map (kbd "W") 'go-projectile-rewrite)
+  (define-key projectile-command-map (kbd "w") 'go-rename)
+  (define-key projectile-command-map (kbd "N") 'go-projectile-get)
+  (define-key projectile-command-map (kbd "G") 'go-projectile-git-grep))
 
 (defun go-projectile-mode ()
   "Hook for `go-mode-hook' to set Go projectile related key bindings."


### PR DESCRIPTION
## Background

I updated projectile today and noticed that projectile has deprecated the usage of `projectile-keymap-prefix` (see [CHANGELOG](https://github.com/bbatsov/projectile/blob/9c6e9813abec6e067c659e9107bf356086a95e04/CHANGELOG.md#master-unreleased)).

This PR makes go-projectile work correctly with the latest projectile version.

## Notes

I am new to elisp and wasn't sure how to use the `map` correctly to make this change 😭 so I went with a more literal definition.